### PR TITLE
Add MP3 decoding support using pure-Go library

### DIFF
--- a/decoder_test.go
+++ b/decoder_test.go
@@ -81,8 +81,46 @@ func TestDecodeAIFF(t *testing.T) {
 	t.Logf("  Duration: %.2f seconds", audio.Duration)
 }
 
-func TestDecodeUnsupportedFormat(t *testing.T) {
+func TestDecodeMP3(t *testing.T) {
 	filename := filepath.Join("data", "windchimes.mp3")
+
+	audio, err := DecodeFile(filename)
+	if err != nil {
+		t.Fatalf("Failed to decode MP3 file: %v", err)
+	}
+
+	// Verify that we got some data
+	if audio == nil {
+		t.Fatal("Audio is nil")
+	}
+
+	// Check that basic fields are populated
+	if audio.NumChannels <= 0 {
+		t.Errorf("Expected NumChannels > 0, got %d", audio.NumChannels)
+	}
+	if audio.SampleRate <= 0 {
+		t.Errorf("Expected SampleRate > 0, got %d", audio.SampleRate)
+	}
+	if audio.BitDepth <= 0 {
+		t.Errorf("Expected BitDepth > 0, got %d", audio.BitDepth)
+	}
+	if len(audio.Data) == 0 {
+		t.Error("Expected audio Data to be non-empty")
+	}
+	if audio.Duration <= 0 {
+		t.Errorf("Expected Duration > 0, got %f", audio.Duration)
+	}
+
+	t.Logf("MP3 Audio Info:")
+	t.Logf("  NumChannels: %d", audio.NumChannels)
+	t.Logf("  SampleRate: %d", audio.SampleRate)
+	t.Logf("  BitDepth: %d", audio.BitDepth)
+	t.Logf("  Data length: %d samples", len(audio.Data))
+	t.Logf("  Duration: %.2f seconds", audio.Duration)
+}
+
+func TestDecodeUnsupportedFormat(t *testing.T) {
+	filename := filepath.Join("data", "windchimes.flac")
 
 	_, err := DecodeFile(filename)
 	if err == nil {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/schollz/audiomorph
 
-go 1.25
+go 1.21
 
 require (
 	github.com/go-audio/aiff v1.1.0 // indirect
 	github.com/go-audio/audio v1.0.0 // indirect
 	github.com/go-audio/riff v1.0.0 // indirect
 	github.com/go-audio/wav v1.1.0 // indirect
+	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 )


### PR DESCRIPTION
- Added github.com/hajimehoshi/go-mp3 dependency for MP3 decoding
- Implemented decodeMP3 function following WAV/AIFF decoder pattern
- Updated DecodeFile to support .mp3 file extension
- Added TestDecodeMP3 test case to verify MP3 decoding functionality
- Updated TestDecodeUnsupportedFormat to use .flac instead of .mp3
- Adjusted go.mod version from 1.25 to 1.21 for compatibility