### PR TITLE
Add GitHub Actions CI workflow and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.25'
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run tests
+      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./coverage.txt
+        fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
+# audiomorph
 
+[![CI](https://github.com/schollz/audiomorph/actions/workflows/ci.yml/badge.svg)](https://github.com/schollz/audiomorph/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/schollz/audiomorph/branch/main/graph/badge.svg)](https://codecov.io/gh/schollz/audiomorph)
+[![Release](https://img.shields.io/github/v/release/schollz/audiomorph)](https://github.com/schollz/audiomorph/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/schollz/audiomorph.svg)](https://pkg.go.dev/github.com/schollz/audiomorph)


### PR DESCRIPTION
- Add CI workflow that runs tests with coverage on Linux
- Upload coverage to Codecov for tracking
- Add badges for CI status, code coverage, latest release, and GoDoc